### PR TITLE
Autopublishing this module to https://nest.land

### DIFF
--- a/.github/workflows/publish-to-nest.land.yml
+++ b/.github/workflows/publish-to-nest.land.yml
@@ -1,0 +1,25 @@
+name: "publish current release to https://nest.land"
+
+on:
+  release:
+    types:
+      - published
+
+jobs:
+  publishToNestDotLand:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Setup repo
+        uses: actions/checkout@v2
+
+      - name: "setup" # check: https://github.com/actions/virtual-environments/issues/1777
+        uses: denolib/setup-deno@v2 
+        with:
+         deno-version: v1.4.6
+
+      - name: "check nest.land"
+        run: | 
+          deno run --allow-net --allow-read --allow-run https://deno.land/x/cicd/publish-on-nest.land.ts ${{ secrets.GITHUB_TOKEN }} ${{ secrets.NESTAPIKEY }} ${{ github.repository }}
+  
+  

--- a/egg.json
+++ b/egg.json
@@ -1,0 +1,10 @@
+{
+    "name": "bwt",
+    "description": "Better Web Token - an iteration of web tokens with a bunch of improvements",
+    "homepage": "https://github.com/chiefbiiko/bwt",
+    "files": [
+    "./**/*.ts",
+    "README.md"
+    ],
+    "entry": "./mod.ts"
+}


### PR DESCRIPTION


This PR contains necessary information to publish this Deno module additionally to https://nest.land as soon as you create a new release.

Requirement: You'll need to register at https://nest.land/ once to get an API Key and add it into your repositories secrets - named NESTAPIKEY - see screenshot.
  
  
![pr-explanation](https://user-images.githubusercontent.com/43786652/98174846-cf611900-1ef5-11eb-8e87-64fa3f1e009f.png)
